### PR TITLE
Upgraded to danger 8.6.1 and added GitHub Actions workflows

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,10 +1,8 @@
 name: PR Linter
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   danger:
     runs-on: ubuntu-latest
-    env:
-      BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,0 +1,19 @@
+name: PR Linter
+on: [push, pull_request]
+jobs:
+  danger:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+          bundler-cache: true
+      - run: |
+          # the personal token is public, this is ok, base64 encode to avoid tripping Github
+          TOKEN=$(echo -n NWY1ZmM5MzEyMzNlYWY4OTZiOGU3MmI3MWQ3Mzk0MzgxMWE4OGVmYwo= | base64 --decode)
+          DANGER_GITHUB_API_TOKEN=$TOKEN bundle exec danger --verbose

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,13 @@
+name: Rubocop
+on: [push, pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+      - run: bundle exec rubocop

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: CI RSpec Test
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: >-
+      Ruby ${{ matrix.entry.ruby }}
+    env:
+      CI: true
+      TESTOPTS: -v
+    runs-on: ubuntu-latest
+    continue-on-error: false
+    strategy:
+      matrix:
+        entry:
+          - { ruby: "2.4", bundler: "2" }
+    steps:
+      - name: repo checkout
+        uses: actions/checkout@v2
+
+      - name: load ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.entry.ruby }}
+          bundler: ${{ matrix.entry.bundler }}
+
+      - name: bundle install
+        run:  bundle install --jobs 4 --retry 3
+
+      - name: test
+        timeout-minutes: 10
+        run: bundle exec rspec spec
+        continue-on-error: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-
-sudo: false
-
-rvm: 2.3.1
-
-before_script:
-  - bundle exec danger

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### 0.1.2 (Next)
 
-* Your contribution here.
+### 0.1.2 (8/18/2022)
+
+* [#5](https://github.com/mongoid/danger/pull/5): Upgraded to danger 8.6.1 and added GitHub Actions workflows - [@joe1chen](https://github.com/joe1chen).
 
 ### 0.1.1 (11/27/2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### 0.1.2 (Next)
 
+* Your contribution here.
+
 ### 0.1.2 (8/18/2022)
 
 * [#5](https://github.com/mongoid/danger/pull/5): Upgraded to danger 8.6.1 and added GitHub Actions workflows - [@joe1chen](https://github.com/joe1chen).

--- a/README.md
+++ b/README.md
@@ -30,12 +30,10 @@ Add `.github/workflows/danger.yml`, eg. [mongoid-compatibility's danger.yml](htt
 
 ```yaml
 name: PR Linter
-on: [push, pull_request]
+on: [pull_request]
 jobs:
   danger:
     runs-on: ubuntu-latest
-    env:
-      BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile
     steps:
       - uses: actions/checkout@v2
         with:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [Danger](http://danger.systems) runs during Mongoid projects' CI process, and gives you a chance to automate common code review chores.
 
-[![Build Status](https://travis-ci.org/mongoid/danger.svg?branch=master)](https://travis-ci.org/mongoid/danger)
+[![Build Status](https://github.com/mongoid/danger/actions/workflows/test.yml/badge.svg)](https://github.com/mongoid/danger/actions)
 
 ### Setup
 
@@ -23,6 +23,32 @@ gem 'mongoid-danger', '~> 0.1.0', require: false
 #### Add Dangerfile
 
 Commit a `Dangerfile`, eg. [mongoid-compatibility's Dangerfile](https://github.com/mongoid/mongoid-compatibility/blob/master/Dangerfile).
+
+#### Add Danger to GitHub Actions
+
+Add `.github/workflows/danger.yml`, eg. [mongoid-compatibility's danger.yml](https://github.com/mongoid/mongoid-compatibility/blob/master/.github/workflows/danger.yml).
+
+```yaml
+name: PR Linter
+on: [push, pull_request]
+jobs:
+  danger:
+    runs-on: ubuntu-latest
+    env:
+      BUNDLE_GEMFILE: ${{ github.workspace }}/Gemfile
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+          bundler-cache: true
+      - run: |
+          # the personal token is public, this is ok, base64 encode to avoid tripping Github
+          TOKEN=$(echo -n NWY1ZmM5MzEyMzNlYWY4OTZiOGU3MmI3MWQ3Mzk0MzgxMWE4OGVmYwo= | base64 --decode)
+          DANGER_GITHUB_API_TOKEN=$TOKEN bundle exec danger --verbose
+```
 
 #### Add Danger to Travis-CI
 

--- a/mongoid-danger.gemspec
+++ b/mongoid-danger.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec'
-  s.add_runtime_dependency 'danger', '~> 4.0.1'
+  s.add_runtime_dependency 'danger', '~> 8.6.1'
   s.add_runtime_dependency 'danger-changelog', '~> 0.2.0'
 end


### PR DESCRIPTION
- Upgraded to Danger 8.6.1 - This is necessary in order to support GitHub Actions support was added in Danger 5.x.
- Added GitHub Actions workflows to run rspec, rubocop, and danger.